### PR TITLE
Fix code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/sf-account-application/sf-account-service/src/main/java/com/nrapendra/salesforce/SalesforceConnector.java
+++ b/sf-account-application/sf-account-service/src/main/java/com/nrapendra/salesforce/SalesforceConnector.java
@@ -39,7 +39,7 @@ public class SalesforceConnector {
     }
 
     public HttpRequestBase findAccountById(SalesforceObject salesforceObject, String accountId){
-
+        validateAccountId(accountId);
         var accessToken = salesforceObject.getAccessToken();
         var salesforceInstanceUrl = salesforceObject.getInstanceUrl();
 
@@ -65,6 +65,7 @@ public class SalesforceConnector {
     }
 
     public HttpRequestBase deleteAccountById(SalesforceObject salesforceObject, String accountId){
+        validateAccountId(accountId);
         var accessToken = salesforceObject.getAccessToken();
         var salesforceInstanceUrl = salesforceObject.getInstanceUrl();
 
@@ -77,6 +78,7 @@ public class SalesforceConnector {
     }
 
     public HttpRequestBase updateAccount(SalesforceObject salesforceObject,String accountId, Account account) throws UnsupportedEncodingException, JsonProcessingException {
+        validateAccountId(accountId);
         var accessToken = salesforceObject.getAccessToken();
         var salesforceInstanceUrl = salesforceObject.getInstanceUrl();
 
@@ -118,6 +120,12 @@ public class SalesforceConnector {
 
     private boolean isNotNullNorEmpty(String value) {
         return Objects.nonNull(value)  &&  !value.isBlank();
+    }
+
+    private void validateAccountId(String accountId) {
+        if (!accountId.matches("^[a-zA-Z0-9]{15}|[a-zA-Z0-9]{18}$")) {
+            throw new IllegalArgumentException("Invalid Salesforce account ID");
+        }
     }
 }
 


### PR DESCRIPTION
Fixes [https://github.com/Nrapendra786/springboot-salesforce-account-demo/security/code-scanning/1](https://github.com/Nrapendra786/springboot-salesforce-account-demo/security/code-scanning/1)

To fix the SSRF vulnerability, we need to validate the `accountId` before using it to construct the URL. One way to do this is to ensure that the `accountId` matches a specific pattern or format that is expected for Salesforce account IDs. Alternatively, we can maintain a list of valid account IDs and check against this list.

The best way to fix this without changing existing functionality is to validate the `accountId` using a regular expression that matches the expected format of Salesforce account IDs. This validation should be added in the `SalesforceConnector` class where the `accountId` is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
